### PR TITLE
PHP 8.4 compat changes

### DIFF
--- a/lib/Api/AccountStatementsApi.php
+++ b/lib/Api/AccountStatementsApi.php
@@ -87,15 +87,15 @@ class AccountStatementsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/ChaserPlansApi.php
+++ b/lib/Api/ChaserPlansApi.php
@@ -84,15 +84,15 @@ class ChaserPlansApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/CheckoutTemplatesApi.php
+++ b/lib/Api/CheckoutTemplatesApi.php
@@ -87,15 +87,15 @@ class CheckoutTemplatesApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/CheckoutsApi.php
+++ b/lib/Api/CheckoutsApi.php
@@ -90,15 +90,15 @@ class CheckoutsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/ConnectionsApi.php
+++ b/lib/Api/ConnectionsApi.php
@@ -87,15 +87,15 @@ class ConnectionsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/CreditNotesApi.php
+++ b/lib/Api/CreditNotesApi.php
@@ -102,15 +102,15 @@ class CreditNotesApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/CustomerAccountsApi.php
+++ b/lib/Api/CustomerAccountsApi.php
@@ -93,9 +93,9 @@ class CustomerAccountsApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/InvoicesApi.php
+++ b/lib/Api/InvoicesApi.php
@@ -117,15 +117,15 @@ class InvoicesApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/LogsApi.php
+++ b/lib/Api/LogsApi.php
@@ -78,15 +78,15 @@ class LogsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/MerchantDomainsApi.php
+++ b/lib/Api/MerchantDomainsApi.php
@@ -84,15 +84,15 @@ class MerchantDomainsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/Model/AccountStatement.php
+++ b/lib/Api/Model/AccountStatement.php
@@ -298,7 +298,7 @@ class AccountStatement implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('checkout_ids', $data ?? [], null);
         $this->setIfExists('connection', $data ?? [], null);

--- a/lib/Api/Model/AccountStatementConnection.php
+++ b/lib/Api/Model/AccountStatementConnection.php
@@ -244,7 +244,7 @@ class AccountStatementConnection implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('type', $data ?? [], null);
 

--- a/lib/Api/Model/AccountStatementConnectionInput.php
+++ b/lib/Api/Model/AccountStatementConnectionInput.php
@@ -244,7 +244,7 @@ class AccountStatementConnectionInput implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('type', $data ?? [], null);
 

--- a/lib/Api/Model/AccountStatementCreateInput.php
+++ b/lib/Api/Model/AccountStatementCreateInput.php
@@ -262,7 +262,7 @@ class AccountStatementCreateInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('connection', $data ?? [], null);
         $this->setIfExists('credit_notes', $data ?? [], null);

--- a/lib/Api/Model/AccountStatementCreditNote.php
+++ b/lib/Api/Model/AccountStatementCreditNote.php
@@ -292,7 +292,7 @@ class AccountStatementCreditNote implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_remaining', $data ?? [], null);
         $this->setIfExists('credit_note_date', $data ?? [], null);

--- a/lib/Api/Model/AccountStatementCreditNoteCreateInput.php
+++ b/lib/Api/Model/AccountStatementCreditNoteCreateInput.php
@@ -280,7 +280,7 @@ class AccountStatementCreditNoteCreateInput implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_remaining', $data ?? [], null);
         $this->setIfExists('credit_note_date', $data ?? [], null);

--- a/lib/Api/Model/AccountStatementInvoice.php
+++ b/lib/Api/Model/AccountStatementInvoice.php
@@ -328,7 +328,7 @@ class AccountStatementInvoice implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_paid', $data ?? [], null);
         $this->setIfExists('amount_pending', $data ?? [], null);

--- a/lib/Api/Model/AccountStatementInvoiceCreateInput.php
+++ b/lib/Api/Model/AccountStatementInvoiceCreateInput.php
@@ -292,7 +292,7 @@ class AccountStatementInvoiceCreateInput implements ModelInterface, ArrayAccess,
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_paid', $data ?? [], null);
         $this->setIfExists('amount_remaining', $data ?? [], null);

--- a/lib/Api/Model/AccountStatementMagentoProxyConnection.php
+++ b/lib/Api/Model/AccountStatementMagentoProxyConnection.php
@@ -242,7 +242,7 @@ class AccountStatementMagentoProxyConnection extends AccountStatementConnection
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/AccountStatementMagentoProxyConnectionInput.php
+++ b/lib/Api/Model/AccountStatementMagentoProxyConnectionInput.php
@@ -248,7 +248,7 @@ class AccountStatementMagentoProxyConnectionInput extends AccountStatementConnec
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/Address.php
+++ b/lib/Api/Model/Address.php
@@ -291,7 +291,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('city', $data ?? [], null);
         $this->setIfExists('company', $data ?? [], null);

--- a/lib/Api/Model/AddressInput.php
+++ b/lib/Api/Model/AddressInput.php
@@ -292,7 +292,7 @@ class AddressInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('city', $data ?? [], null);
         $this->setIfExists('company', $data ?? [], null);

--- a/lib/Api/Model/CardPaymentMethodSettings.php
+++ b/lib/Api/Model/CardPaymentMethodSettings.php
@@ -250,7 +250,7 @@ class CardPaymentMethodSettings implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('initialization_token', $data ?? [], null);
         $this->setIfExists('live_status', $data ?? [], null);

--- a/lib/Api/Model/ChaserPlan.php
+++ b/lib/Api/Model/ChaserPlan.php
@@ -256,7 +256,7 @@ class ChaserPlan implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/lib/Api/Model/ChaserPlanCreateInput.php
+++ b/lib/Api/Model/ChaserPlanCreateInput.php
@@ -250,7 +250,7 @@ class ChaserPlanCreateInput implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('schedules', $data ?? [], null);

--- a/lib/Api/Model/ChaserPlanPage.php
+++ b/lib/Api/Model/ChaserPlanPage.php
@@ -256,7 +256,7 @@ class ChaserPlanPage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/ChaserPlanSchedule.php
+++ b/lib/Api/Model/ChaserPlanSchedule.php
@@ -271,7 +271,7 @@ class ChaserPlanSchedule implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('notification_channel', $data ?? [], null);

--- a/lib/Api/Model/ChaserPlanScheduleCreateInput.php
+++ b/lib/Api/Model/ChaserPlanScheduleCreateInput.php
@@ -265,7 +265,7 @@ class ChaserPlanScheduleCreateInput implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('notification_channel', $data ?? [], null);
         $this->setIfExists('offset_time_in_seconds', $data ?? [], null);

--- a/lib/Api/Model/Checkout.php
+++ b/lib/Api/Model/Checkout.php
@@ -382,7 +382,7 @@ class Checkout implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('billing_address', $data ?? [], null);

--- a/lib/Api/Model/CheckoutApplePaySettings.php
+++ b/lib/Api/Model/CheckoutApplePaySettings.php
@@ -256,7 +256,7 @@ class CheckoutApplePaySettings implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutApplePaySettingsInput.php
+++ b/lib/Api/Model/CheckoutApplePaySettingsInput.php
@@ -256,7 +256,7 @@ class CheckoutApplePaySettingsInput implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutApplePaySettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutApplePaySettingsUpdateInput.php
@@ -256,7 +256,7 @@ class CheckoutApplePaySettingsUpdateInput implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCardSettings.php
+++ b/lib/Api/Model/CheckoutCardSettings.php
@@ -256,7 +256,7 @@ class CheckoutCardSettings implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCardSettingsInput.php
+++ b/lib/Api/Model/CheckoutCardSettingsInput.php
@@ -256,7 +256,7 @@ class CheckoutCardSettingsInput implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCardSettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutCardSettingsUpdateInput.php
@@ -256,7 +256,7 @@ class CheckoutCardSettingsUpdateInput implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutClearpaySettings.php
+++ b/lib/Api/Model/CheckoutClearpaySettings.php
@@ -250,7 +250,7 @@ class CheckoutClearpaySettings implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutClearpaySettingsInput.php
+++ b/lib/Api/Model/CheckoutClearpaySettingsInput.php
@@ -250,7 +250,7 @@ class CheckoutClearpaySettingsInput implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutClearpaySettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutClearpaySettingsUpdateInput.php
@@ -250,7 +250,7 @@ class CheckoutClearpaySettingsUpdateInput implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCreateInput.php
+++ b/lib/Api/Model/CheckoutCreateInput.php
@@ -322,7 +322,7 @@ class CheckoutCreateInput implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('billing_address', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCustomerFields.php
+++ b/lib/Api/Model/CheckoutCustomerFields.php
@@ -249,7 +249,7 @@ class CheckoutCustomerFields implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('optional', $data ?? [], null);
         $this->setIfExists('required', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCustomerFieldsInput.php
+++ b/lib/Api/Model/CheckoutCustomerFieldsInput.php
@@ -250,7 +250,7 @@ class CheckoutCustomerFieldsInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('optional', $data ?? [], null);
         $this->setIfExists('required', $data ?? [], null);

--- a/lib/Api/Model/CheckoutCustomerFieldsUpdateInput.php
+++ b/lib/Api/Model/CheckoutCustomerFieldsUpdateInput.php
@@ -250,7 +250,7 @@ class CheckoutCustomerFieldsUpdateInput implements ModelInterface, ArrayAccess, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('optional', $data ?? [], null);
         $this->setIfExists('required', $data ?? [], null);

--- a/lib/Api/Model/CheckoutGooglePaySettings.php
+++ b/lib/Api/Model/CheckoutGooglePaySettings.php
@@ -256,7 +256,7 @@ class CheckoutGooglePaySettings implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutGooglePaySettingsInput.php
+++ b/lib/Api/Model/CheckoutGooglePaySettingsInput.php
@@ -256,7 +256,7 @@ class CheckoutGooglePaySettingsInput implements ModelInterface, ArrayAccess, \Js
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutGooglePaySettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutGooglePaySettingsUpdateInput.php
@@ -256,7 +256,7 @@ class CheckoutGooglePaySettingsUpdateInput implements ModelInterface, ArrayAcces
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutKlarnaSettings.php
+++ b/lib/Api/Model/CheckoutKlarnaSettings.php
@@ -250,7 +250,7 @@ class CheckoutKlarnaSettings implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutKlarnaSettingsInput.php
+++ b/lib/Api/Model/CheckoutKlarnaSettingsInput.php
@@ -250,7 +250,7 @@ class CheckoutKlarnaSettingsInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutKlarnaSettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutKlarnaSettingsUpdateInput.php
@@ -250,7 +250,7 @@ class CheckoutKlarnaSettingsUpdateInput implements ModelInterface, ArrayAccess, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPage.php
+++ b/lib/Api/Model/CheckoutPage.php
@@ -256,7 +256,7 @@ class CheckoutPage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPayByBankSettings.php
+++ b/lib/Api/Model/CheckoutPayByBankSettings.php
@@ -256,7 +256,7 @@ class CheckoutPayByBankSettings implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPayByBankSettingsInput.php
+++ b/lib/Api/Model/CheckoutPayByBankSettingsInput.php
@@ -256,7 +256,7 @@ class CheckoutPayByBankSettingsInput implements ModelInterface, ArrayAccess, \Js
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPayByBankSettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutPayByBankSettingsUpdateInput.php
@@ -256,7 +256,7 @@ class CheckoutPayByBankSettingsUpdateInput implements ModelInterface, ArrayAcces
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('capture_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPaymentMethodLimit.php
+++ b/lib/Api/Model/CheckoutPaymentMethodLimit.php
@@ -244,7 +244,7 @@ class CheckoutPaymentMethodLimit implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('total', $data ?? [], null);
     }

--- a/lib/Api/Model/CheckoutPaymentMethodLimitInput.php
+++ b/lib/Api/Model/CheckoutPaymentMethodLimitInput.php
@@ -244,7 +244,7 @@ class CheckoutPaymentMethodLimitInput implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('total', $data ?? [], null);
     }

--- a/lib/Api/Model/CheckoutPaymentMethodLimitUpdateInput.php
+++ b/lib/Api/Model/CheckoutPaymentMethodLimitUpdateInput.php
@@ -244,7 +244,7 @@ class CheckoutPaymentMethodLimitUpdateInput implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('total', $data ?? [], null);
     }

--- a/lib/Api/Model/CheckoutPaymentMethodSettings.php
+++ b/lib/Api/Model/CheckoutPaymentMethodSettings.php
@@ -280,7 +280,7 @@ class CheckoutPaymentMethodSettings implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('apple_pay', $data ?? [], null);
         $this->setIfExists('card', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPaymentMethodSettingsInput.php
+++ b/lib/Api/Model/CheckoutPaymentMethodSettingsInput.php
@@ -280,7 +280,7 @@ class CheckoutPaymentMethodSettingsInput implements ModelInterface, ArrayAccess,
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('apple_pay', $data ?? [], null);
         $this->setIfExists('card', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPaymentMethodSettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutPaymentMethodSettingsUpdateInput.php
@@ -280,7 +280,7 @@ class CheckoutPaymentMethodSettingsUpdateInput implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('apple_pay', $data ?? [], null);
         $this->setIfExists('card', $data ?? [], null);

--- a/lib/Api/Model/CheckoutPaymentMethodTotalLimit.php
+++ b/lib/Api/Model/CheckoutPaymentMethodTotalLimit.php
@@ -256,7 +256,7 @@ class CheckoutPaymentMethodTotalLimit implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('currency', $data ?? [], null);
         $this->setIfExists('max', $data ?? [], null);

--- a/lib/Api/Model/CheckoutTemplate.php
+++ b/lib/Api/Model/CheckoutTemplate.php
@@ -339,7 +339,7 @@ class CheckoutTemplate implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_type', $data ?? [], null);
         $this->setIfExists('created_at', $data ?? [], null);

--- a/lib/Api/Model/CheckoutTemplateCreateInput.php
+++ b/lib/Api/Model/CheckoutTemplateCreateInput.php
@@ -328,7 +328,7 @@ class CheckoutTemplateCreateInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutTemplatePage.php
+++ b/lib/Api/Model/CheckoutTemplatePage.php
@@ -256,7 +256,7 @@ class CheckoutTemplatePage implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/CheckoutTemplateUpdateInput.php
+++ b/lib/Api/Model/CheckoutTemplateUpdateInput.php
@@ -316,7 +316,7 @@ class CheckoutTemplateUpdateInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_type', $data ?? [], null);
         $this->setIfExists('customer_fields', $data ?? [], null);

--- a/lib/Api/Model/CheckoutZopaRetailFinanceSettings.php
+++ b/lib/Api/Model/CheckoutZopaRetailFinanceSettings.php
@@ -250,7 +250,7 @@ class CheckoutZopaRetailFinanceSettings implements ModelInterface, ArrayAccess, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutZopaRetailFinanceSettingsInput.php
+++ b/lib/Api/Model/CheckoutZopaRetailFinanceSettingsInput.php
@@ -250,7 +250,7 @@ class CheckoutZopaRetailFinanceSettingsInput implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/CheckoutZopaRetailFinanceSettingsUpdateInput.php
+++ b/lib/Api/Model/CheckoutZopaRetailFinanceSettingsUpdateInput.php
@@ -250,7 +250,7 @@ class CheckoutZopaRetailFinanceSettingsUpdateInput implements ModelInterface, Ar
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_fields', $data ?? [], null);
         $this->setIfExists('limits', $data ?? [], null);

--- a/lib/Api/Model/Connection.php
+++ b/lib/Api/Model/Connection.php
@@ -274,7 +274,7 @@ class Connection implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('created_at', $data ?? [], null);
         $this->setIfExists('data', $data ?? [], null);

--- a/lib/Api/Model/ConnectionCreateInput.php
+++ b/lib/Api/Model/ConnectionCreateInput.php
@@ -244,7 +244,7 @@ class ConnectionCreateInput implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('data', $data ?? [], null);
     }

--- a/lib/Api/Model/ConnectionData.php
+++ b/lib/Api/Model/ConnectionData.php
@@ -244,7 +244,7 @@ class ConnectionData implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('type', $data ?? [], null);
 

--- a/lib/Api/Model/ConnectionDataInput.php
+++ b/lib/Api/Model/ConnectionDataInput.php
@@ -244,7 +244,7 @@ class ConnectionDataInput implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('type', $data ?? [], null);
 

--- a/lib/Api/Model/ConnectionPage.php
+++ b/lib/Api/Model/ConnectionPage.php
@@ -256,7 +256,7 @@ class ConnectionPage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/CreditNote.php
+++ b/lib/Api/Model/CreditNote.php
@@ -343,7 +343,7 @@ class CreditNote implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('applied_to_invoice_ids', $data ?? [], null);
         $this->setIfExists('credit_note_date', $data ?? [], null);

--- a/lib/Api/Model/CreditNoteCreateInput.php
+++ b/lib/Api/Model/CreditNoteCreateInput.php
@@ -301,7 +301,7 @@ class CreditNoteCreateInput implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('credit_note_date', $data ?? [], null);
         $this->setIfExists('credit_note_number', $data ?? [], null);

--- a/lib/Api/Model/CreditNoteDownload.php
+++ b/lib/Api/Model/CreditNoteDownload.php
@@ -250,7 +250,7 @@ class CreditNoteDownload implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('expires_at', $data ?? [], null);
         $this->setIfExists('url', $data ?? [], null);

--- a/lib/Api/Model/CreditNoteItem.php
+++ b/lib/Api/Model/CreditNoteItem.php
@@ -286,7 +286,7 @@ class CreditNoteItem implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('invoice_item_id', $data ?? [], null);

--- a/lib/Api/Model/CreditNoteItemCreateInput.php
+++ b/lib/Api/Model/CreditNoteItemCreateInput.php
@@ -274,7 +274,7 @@ class CreditNoteItemCreateInput implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('invoice_item_id', $data ?? [], null);
         $this->setIfExists('merchant_id', $data ?? [], null);

--- a/lib/Api/Model/CreditNotePage.php
+++ b/lib/Api/Model/CreditNotePage.php
@@ -256,7 +256,7 @@ class CreditNotePage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/CreditNoteUpdateInput.php
+++ b/lib/Api/Model/CreditNoteUpdateInput.php
@@ -295,7 +295,7 @@ class CreditNoteUpdateInput implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('credit_note_date', $data ?? [], null);
         $this->setIfExists('credit_note_number', $data ?? [], null);

--- a/lib/Api/Model/Customer.php
+++ b/lib/Api/Model/Customer.php
@@ -261,7 +261,7 @@ class Customer implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('email', $data ?? [], null);
         $this->setIfExists('given_name', $data ?? [], null);

--- a/lib/Api/Model/CustomerAccount.php
+++ b/lib/Api/Model/CustomerAccount.php
@@ -298,7 +298,7 @@ class CustomerAccount implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('email', $data ?? [], null);

--- a/lib/Api/Model/CustomerAccountAddress.php
+++ b/lib/Api/Model/CustomerAccountAddress.php
@@ -292,7 +292,7 @@ class CustomerAccountAddress implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('city', $data ?? [], null);
         $this->setIfExists('company', $data ?? [], null);

--- a/lib/Api/Model/CustomerAccountAddressCreateInput.php
+++ b/lib/Api/Model/CustomerAccountAddressCreateInput.php
@@ -292,7 +292,7 @@ class CustomerAccountAddressCreateInput implements ModelInterface, ArrayAccess, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('city', $data ?? [], null);
         $this->setIfExists('company', $data ?? [], null);

--- a/lib/Api/Model/CustomerAccountCreateInput.php
+++ b/lib/Api/Model/CustomerAccountCreateInput.php
@@ -292,7 +292,7 @@ class CustomerAccountCreateInput implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('email', $data ?? [], null);

--- a/lib/Api/Model/CustomerAccountPage.php
+++ b/lib/Api/Model/CustomerAccountPage.php
@@ -256,7 +256,7 @@ class CustomerAccountPage implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/CustomerInput.php
+++ b/lib/Api/Model/CustomerInput.php
@@ -262,7 +262,7 @@ class CustomerInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('email', $data ?? [], null);
         $this->setIfExists('given_name', $data ?? [], null);

--- a/lib/Api/Model/GooglePayConnectionData.php
+++ b/lib/Api/Model/GooglePayConnectionData.php
@@ -242,7 +242,7 @@ class GooglePayConnectionData extends ConnectionData
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/GooglePayConnectionDataInput.php
+++ b/lib/Api/Model/GooglePayConnectionDataInput.php
@@ -236,7 +236,7 @@ class GooglePayConnectionDataInput extends ConnectionDataInput
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/Invoice.php
+++ b/lib/Api/Model/Invoice.php
@@ -370,7 +370,7 @@ class Invoice implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount_credited', $data ?? [], null);
         $this->setIfExists('amount_paid', $data ?? [], null);

--- a/lib/Api/Model/InvoiceCreateInput.php
+++ b/lib/Api/Model/InvoiceCreateInput.php
@@ -298,7 +298,7 @@ class InvoiceCreateInput implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('chaser_plan_id', $data ?? [], null);
         $this->setIfExists('customer_account_id', $data ?? [], null);

--- a/lib/Api/Model/InvoiceCustomerAccount.php
+++ b/lib/Api/Model/InvoiceCustomerAccount.php
@@ -298,7 +298,7 @@ class InvoiceCustomerAccount implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('email', $data ?? [], null);

--- a/lib/Api/Model/InvoiceCustomerAccountAddress.php
+++ b/lib/Api/Model/InvoiceCustomerAccountAddress.php
@@ -292,7 +292,7 @@ class InvoiceCustomerAccountAddress implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('city', $data ?? [], null);
         $this->setIfExists('company', $data ?? [], null);

--- a/lib/Api/Model/InvoiceDownload.php
+++ b/lib/Api/Model/InvoiceDownload.php
@@ -250,7 +250,7 @@ class InvoiceDownload implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('expires_at', $data ?? [], null);
         $this->setIfExists('url', $data ?? [], null);

--- a/lib/Api/Model/InvoiceItem.php
+++ b/lib/Api/Model/InvoiceItem.php
@@ -303,7 +303,7 @@ class InvoiceItem implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/lib/Api/Model/InvoiceItemCreateInput.php
+++ b/lib/Api/Model/InvoiceItemCreateInput.php
@@ -292,7 +292,7 @@ class InvoiceItemCreateInput implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('price', $data ?? [], null);

--- a/lib/Api/Model/InvoiceItemSupplyDateDto.php
+++ b/lib/Api/Model/InvoiceItemSupplyDateDto.php
@@ -250,7 +250,7 @@ class InvoiceItemSupplyDateDto implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('end', $data ?? [], null);
         $this->setIfExists('start', $data ?? [], null);

--- a/lib/Api/Model/InvoiceItemSupplyDateInputDto.php
+++ b/lib/Api/Model/InvoiceItemSupplyDateInputDto.php
@@ -249,7 +249,7 @@ class InvoiceItemSupplyDateInputDto implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('end', $data ?? [], null);
         $this->setIfExists('start', $data ?? [], null);

--- a/lib/Api/Model/InvoiceMerchant.php
+++ b/lib/Api/Model/InvoiceMerchant.php
@@ -268,7 +268,7 @@ class InvoiceMerchant implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('address', $data ?? [], null);
         $this->setIfExists('company_number', $data ?? [], null);

--- a/lib/Api/Model/InvoiceMerchantAddress.php
+++ b/lib/Api/Model/InvoiceMerchantAddress.php
@@ -274,7 +274,7 @@ class InvoiceMerchantAddress implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('city_or_town', $data ?? [], null);
         $this->setIfExists('country_code', $data ?? [], null);

--- a/lib/Api/Model/InvoiceNotification.php
+++ b/lib/Api/Model/InvoiceNotification.php
@@ -324,7 +324,7 @@ class InvoiceNotification implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('created_at', $data ?? [], null);
         $this->setIfExists('email', $data ?? [], null);

--- a/lib/Api/Model/InvoiceNotificationInput.php
+++ b/lib/Api/Model/InvoiceNotificationInput.php
@@ -259,7 +259,7 @@ class InvoiceNotificationInput implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('type', $data ?? [], null);
     }

--- a/lib/Api/Model/InvoiceNotificationPage.php
+++ b/lib/Api/Model/InvoiceNotificationPage.php
@@ -256,7 +256,7 @@ class InvoiceNotificationPage implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/InvoiceNotificationSentBy.php
+++ b/lib/Api/Model/InvoiceNotificationSentBy.php
@@ -256,7 +256,7 @@ class InvoiceNotificationSentBy implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('given_name', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/lib/Api/Model/InvoicePage.php
+++ b/lib/Api/Model/InvoicePage.php
@@ -256,7 +256,7 @@ class InvoicePage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/InvoiceUpdateInputDto.php
+++ b/lib/Api/Model/InvoiceUpdateInputDto.php
@@ -285,7 +285,7 @@ class InvoiceUpdateInputDto implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('customer_notes', $data ?? [], null);
         $this->setIfExists('due_date', $data ?? [], null);

--- a/lib/Api/Model/Item.php
+++ b/lib/Api/Model/Item.php
@@ -298,7 +298,7 @@ class Item implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('created_at', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/lib/Api/Model/ItemInput.php
+++ b/lib/Api/Model/ItemInput.php
@@ -292,7 +292,7 @@ class ItemInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('price', $data ?? [], null);

--- a/lib/Api/Model/KlarnaConnectionData.php
+++ b/lib/Api/Model/KlarnaConnectionData.php
@@ -254,7 +254,7 @@ class KlarnaConnectionData extends ConnectionData
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/KlarnaConnectionDataInput.php
+++ b/lib/Api/Model/KlarnaConnectionDataInput.php
@@ -248,7 +248,7 @@ class KlarnaConnectionDataInput extends ConnectionDataInput
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/KlarnaPaymentMethodSettings.php
+++ b/lib/Api/Model/KlarnaPaymentMethodSettings.php
@@ -244,7 +244,7 @@ class KlarnaPaymentMethodSettings implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('client_identifier', $data ?? [], null);
     }

--- a/lib/Api/Model/LogCreateInput.php
+++ b/lib/Api/Model/LogCreateInput.php
@@ -262,7 +262,7 @@ class LogCreateInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('action_type', $data ?? [], null);
         $this->setIfExists('current_data', $data ?? [], null);

--- a/lib/Api/Model/LogRecord.php
+++ b/lib/Api/Model/LogRecord.php
@@ -316,7 +316,7 @@ class LogRecord implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('action_type', $data ?? [], null);
         $this->setIfExists('actor_type', $data ?? [], null);

--- a/lib/Api/Model/MagentoConnectionData.php
+++ b/lib/Api/Model/MagentoConnectionData.php
@@ -272,7 +272,7 @@ class MagentoConnectionData extends ConnectionData
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/MagentoConnectionDataInput.php
+++ b/lib/Api/Model/MagentoConnectionDataInput.php
@@ -266,7 +266,7 @@ class MagentoConnectionDataInput extends ConnectionDataInput
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/MagentoProxyConnectionData.php
+++ b/lib/Api/Model/MagentoProxyConnectionData.php
@@ -272,7 +272,7 @@ class MagentoProxyConnectionData extends ConnectionData
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/MagentoProxyConnectionDataInput.php
+++ b/lib/Api/Model/MagentoProxyConnectionDataInput.php
@@ -266,7 +266,7 @@ class MagentoProxyConnectionDataInput extends ConnectionDataInput
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/MerchantDomains.php
+++ b/lib/Api/Model/MerchantDomains.php
@@ -250,7 +250,7 @@ class MerchantDomains implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('domain', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/lib/Api/Model/MerchantDomainsCreateInput.php
+++ b/lib/Api/Model/MerchantDomainsCreateInput.php
@@ -244,7 +244,7 @@ class MerchantDomainsCreateInput implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('domains_to_add', $data ?? [], null);
     }

--- a/lib/Api/Model/MerchantDomainsPage.php
+++ b/lib/Api/Model/MerchantDomainsPage.php
@@ -256,7 +256,7 @@ class MerchantDomainsPage implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/MerchantLogoWithUrls.php
+++ b/lib/Api/Model/MerchantLogoWithUrls.php
@@ -262,7 +262,7 @@ class MerchantLogoWithUrls implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('document_id', $data ?? [], null);
         $this->setIfExists('size104x104', $data ?? [], null);

--- a/lib/Api/Model/Money.php
+++ b/lib/Api/Model/Money.php
@@ -249,7 +249,7 @@ class Money implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('currency', $data ?? [], null);

--- a/lib/Api/Model/MoneyInput.php
+++ b/lib/Api/Model/MoneyInput.php
@@ -270,7 +270,7 @@ class MoneyInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('currency', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscription.php
+++ b/lib/Api/Model/NotificationSubscription.php
@@ -298,7 +298,7 @@ class NotificationSubscription implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('active_from', $data ?? [], null);
         $this->setIfExists('active_to', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscriptionConfiguration.php
+++ b/lib/Api/Model/NotificationSubscriptionConfiguration.php
@@ -271,7 +271,7 @@ class NotificationSubscriptionConfiguration implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('allowed_channels', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscriptionConfigurationInput.php
+++ b/lib/Api/Model/NotificationSubscriptionConfigurationInput.php
@@ -265,7 +265,7 @@ class NotificationSubscriptionConfigurationInput implements ModelInterface, Arra
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('allowed_channels', $data ?? [], null);
         $this->setIfExists('notification_type', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscriptionCreateInput.php
+++ b/lib/Api/Model/NotificationSubscriptionCreateInput.php
@@ -274,7 +274,7 @@ class NotificationSubscriptionCreateInput implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('active_from', $data ?? [], null);
         $this->setIfExists('active_to', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscriptionPage.php
+++ b/lib/Api/Model/NotificationSubscriptionPage.php
@@ -256,7 +256,7 @@ class NotificationSubscriptionPage implements ModelInterface, ArrayAccess, \Json
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscriptionRecipient.php
+++ b/lib/Api/Model/NotificationSubscriptionRecipient.php
@@ -250,7 +250,7 @@ class NotificationSubscriptionRecipient implements ModelInterface, ArrayAccess, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('email', $data ?? [], null);
         $this->setIfExists('phone_number', $data ?? [], null);

--- a/lib/Api/Model/NotificationSubscriptionRecipientInput.php
+++ b/lib/Api/Model/NotificationSubscriptionRecipientInput.php
@@ -250,7 +250,7 @@ class NotificationSubscriptionRecipientInput implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('email', $data ?? [], null);
         $this->setIfExists('phone_number', $data ?? [], null);

--- a/lib/Api/Model/Order.php
+++ b/lib/Api/Model/Order.php
@@ -316,7 +316,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('billing_address', $data ?? [], null);

--- a/lib/Api/Model/OrdersPage.php
+++ b/lib/Api/Model/OrdersPage.php
@@ -256,7 +256,7 @@ class OrdersPage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PageCheckout.php
+++ b/lib/Api/Model/PageCheckout.php
@@ -255,7 +255,7 @@ class PageCheckout implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PageCheckoutTemplate.php
+++ b/lib/Api/Model/PageCheckoutTemplate.php
@@ -255,7 +255,7 @@ class PageCheckoutTemplate implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PageConnection.php
+++ b/lib/Api/Model/PageConnection.php
@@ -255,7 +255,7 @@ class PageConnection implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PageNotificationSubscription.php
+++ b/lib/Api/Model/PageNotificationSubscription.php
@@ -255,7 +255,7 @@ class PageNotificationSubscription implements ModelInterface, ArrayAccess, \Json
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PagePaymentLink.php
+++ b/lib/Api/Model/PagePaymentLink.php
@@ -255,7 +255,7 @@ class PagePaymentLink implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PagePaymentMethodDetail.php
+++ b/lib/Api/Model/PagePaymentMethodDetail.php
@@ -256,7 +256,7 @@ class PagePaymentMethodDetail implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PageTheme.php
+++ b/lib/Api/Model/PageTheme.php
@@ -255,7 +255,7 @@ class PageTheme implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PageWebhook.php
+++ b/lib/Api/Model/PageWebhook.php
@@ -255,7 +255,7 @@ class PageWebhook implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/Pageable.php
+++ b/lib/Api/Model/Pageable.php
@@ -249,7 +249,7 @@ class Pageable implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('limit', $data ?? [], null);
         $this->setIfExists('offset', $data ?? [], null);

--- a/lib/Api/Model/Payment.php
+++ b/lib/Api/Model/Payment.php
@@ -316,7 +316,7 @@ class Payment implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('authorization_expires_at', $data ?? [], null);

--- a/lib/Api/Model/PaymentAction.php
+++ b/lib/Api/Model/PaymentAction.php
@@ -256,7 +256,7 @@ class PaymentAction implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('method', $data ?? [], null);
         $this->setIfExists('type', $data ?? [], null);

--- a/lib/Api/Model/PaymentLink.php
+++ b/lib/Api/Model/PaymentLink.php
@@ -316,7 +316,7 @@ class PaymentLink implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('checkout_ids', $data ?? [], null);

--- a/lib/Api/Model/PaymentLinkCreateInput.php
+++ b/lib/Api/Model/PaymentLinkCreateInput.php
@@ -274,7 +274,7 @@ class PaymentLinkCreateInput implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('checkout_template_id', $data ?? [], null);

--- a/lib/Api/Model/PaymentLinkPage.php
+++ b/lib/Api/Model/PaymentLinkPage.php
@@ -256,7 +256,7 @@ class PaymentLinkPage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PaymentMethodAsset.php
+++ b/lib/Api/Model/PaymentMethodAsset.php
@@ -256,7 +256,7 @@ class PaymentMethodAsset implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('asset_type', $data ?? [], null);
         $this->setIfExists('attributes', $data ?? [], null);

--- a/lib/Api/Model/PaymentMethodDetail.php
+++ b/lib/Api/Model/PaymentMethodDetail.php
@@ -274,7 +274,7 @@ class PaymentMethodDetail implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('limits', $data ?? [], null);
         $this->setIfExists('logo_url', $data ?? [], null);

--- a/lib/Api/Model/PaymentMethodDetailsPage.php
+++ b/lib/Api/Model/PaymentMethodDetailsPage.php
@@ -256,7 +256,7 @@ class PaymentMethodDetailsPage implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/PaymentMethodLimit.php
+++ b/lib/Api/Model/PaymentMethodLimit.php
@@ -250,7 +250,7 @@ class PaymentMethodLimit implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('expires_at', $data ?? [], null);
         $this->setIfExists('total', $data ?? [], null);

--- a/lib/Api/Model/PaymentMethodSettings.php
+++ b/lib/Api/Model/PaymentMethodSettings.php
@@ -274,7 +274,7 @@ class PaymentMethodSettings implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('assets', $data ?? [], null);
         $this->setIfExists('card', $data ?? [], null);

--- a/lib/Api/Model/PaymentMethodTotalLimit.php
+++ b/lib/Api/Model/PaymentMethodTotalLimit.php
@@ -256,7 +256,7 @@ class PaymentMethodTotalLimit implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('currency', $data ?? [], null);
         $this->setIfExists('max', $data ?? [], null);

--- a/lib/Api/Model/PaymentSession.php
+++ b/lib/Api/Model/PaymentSession.php
@@ -369,7 +369,7 @@ class PaymentSession implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('checkout_id', $data ?? [], null);

--- a/lib/Api/Model/PaymentSessionCreateInput.php
+++ b/lib/Api/Model/PaymentSessionCreateInput.php
@@ -334,7 +334,7 @@ class PaymentSessionCreateInput implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('customer', $data ?? [], null);

--- a/lib/Api/Model/PaymentSettings.php
+++ b/lib/Api/Model/PaymentSettings.php
@@ -250,7 +250,7 @@ class PaymentSettings implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('merchant', $data ?? [], null);
         $this->setIfExists('payment_methods', $data ?? [], null);

--- a/lib/Api/Model/PaymentSettingsContext.php
+++ b/lib/Api/Model/PaymentSettingsContext.php
@@ -274,7 +274,7 @@ class PaymentSettingsContext implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('checkout_id', $data ?? [], null);

--- a/lib/Api/Model/PaymentSettingsMerchant.php
+++ b/lib/Api/Model/PaymentSettingsMerchant.php
@@ -256,7 +256,7 @@ class PaymentSettingsMerchant implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('logo', $data ?? [], null);

--- a/lib/Api/Model/PaymentSummary.php
+++ b/lib/Api/Model/PaymentSummary.php
@@ -267,7 +267,7 @@ class PaymentSummary implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('is_manually_capturable', $data ?? [], null);
         $this->setIfExists('is_refundable', $data ?? [], null);

--- a/lib/Api/Model/Refund.php
+++ b/lib/Api/Model/Refund.php
@@ -298,7 +298,7 @@ class Refund implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('created_at', $data ?? [], null);

--- a/lib/Api/Model/RefundCreateInput.php
+++ b/lib/Api/Model/RefundCreateInput.php
@@ -250,7 +250,7 @@ class RefundCreateInput implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('reason', $data ?? [], null);

--- a/lib/Api/Model/ShipmentTracking.php
+++ b/lib/Api/Model/ShipmentTracking.php
@@ -256,7 +256,7 @@ class ShipmentTracking implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
         $this->setIfExists('items', $data ?? [], null);

--- a/lib/Api/Model/ShipmentTrackingCreateInput.php
+++ b/lib/Api/Model/ShipmentTrackingCreateInput.php
@@ -250,7 +250,7 @@ class ShipmentTrackingCreateInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('items', $data ?? [], null);
         $this->setIfExists('tracking_detail', $data ?? [], null);

--- a/lib/Api/Model/ShipmentTrackingDetail.php
+++ b/lib/Api/Model/ShipmentTrackingDetail.php
@@ -256,7 +256,7 @@ class ShipmentTrackingDetail implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('carrier_code', $data ?? [], null);
         $this->setIfExists('title', $data ?? [], null);

--- a/lib/Api/Model/ShipmentTrackingDetailInput.php
+++ b/lib/Api/Model/ShipmentTrackingDetailInput.php
@@ -256,7 +256,7 @@ class ShipmentTrackingDetailInput implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('carrier_code', $data ?? [], null);
         $this->setIfExists('title', $data ?? [], null);

--- a/lib/Api/Model/ShipmentTrackingItem.php
+++ b/lib/Api/Model/ShipmentTrackingItem.php
@@ -256,7 +256,7 @@ class ShipmentTrackingItem implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('quantity', $data ?? [], null);

--- a/lib/Api/Model/ShipmentTrackingItemInput.php
+++ b/lib/Api/Model/ShipmentTrackingItemInput.php
@@ -256,7 +256,7 @@ class ShipmentTrackingItemInput implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('quantity', $data ?? [], null);

--- a/lib/Api/Model/StartEnd.php
+++ b/lib/Api/Model/StartEnd.php
@@ -250,7 +250,7 @@ class StartEnd implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('end', $data ?? [], null);
         $this->setIfExists('start', $data ?? [], null);

--- a/lib/Api/Model/StatementExportRequest.php
+++ b/lib/Api/Model/StatementExportRequest.php
@@ -269,7 +269,7 @@ class StatementExportRequest implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('disbursement_batch_id', $data ?? [], null);
         $this->setIfExists('export_format', $data ?? [], null);

--- a/lib/Api/Model/Theme.php
+++ b/lib/Api/Model/Theme.php
@@ -292,7 +292,7 @@ class Theme implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background_image', $data ?? [], null);
         $this->setIfExists('colors', $data ?? [], null);

--- a/lib/Api/Model/ThemeBackgroundImage.php
+++ b/lib/Api/Model/ThemeBackgroundImage.php
@@ -250,7 +250,7 @@ class ThemeBackgroundImage implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('desktop', $data ?? [], null);
         $this->setIfExists('mobile', $data ?? [], null);

--- a/lib/Api/Model/ThemeBackgroundImageCreateInput.php
+++ b/lib/Api/Model/ThemeBackgroundImageCreateInput.php
@@ -250,7 +250,7 @@ class ThemeBackgroundImageCreateInput implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('desktop', $data ?? [], null);
         $this->setIfExists('mobile', $data ?? [], null);

--- a/lib/Api/Model/ThemeBackgroundImageUpdateInput.php
+++ b/lib/Api/Model/ThemeBackgroundImageUpdateInput.php
@@ -250,7 +250,7 @@ class ThemeBackgroundImageUpdateInput implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('desktop', $data ?? [], null);
         $this->setIfExists('mobile', $data ?? [], null);

--- a/lib/Api/Model/ThemeColors.php
+++ b/lib/Api/Model/ThemeColors.php
@@ -274,7 +274,7 @@ class ThemeColors implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background', $data ?? [], null);
         $this->setIfExists('primary', $data ?? [], null);

--- a/lib/Api/Model/ThemeColorsCreateInput.php
+++ b/lib/Api/Model/ThemeColorsCreateInput.php
@@ -274,7 +274,7 @@ class ThemeColorsCreateInput implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background', $data ?? [], null);
         $this->setIfExists('primary', $data ?? [], null);

--- a/lib/Api/Model/ThemeColorsUpdateInput.php
+++ b/lib/Api/Model/ThemeColorsUpdateInput.php
@@ -274,7 +274,7 @@ class ThemeColorsUpdateInput implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background', $data ?? [], null);
         $this->setIfExists('primary', $data ?? [], null);

--- a/lib/Api/Model/ThemeCreateInput.php
+++ b/lib/Api/Model/ThemeCreateInput.php
@@ -268,7 +268,7 @@ class ThemeCreateInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background_image', $data ?? [], null);
         $this->setIfExists('colors', $data ?? [], null);

--- a/lib/Api/Model/ThemeDesktopBackgroundImage.php
+++ b/lib/Api/Model/ThemeDesktopBackgroundImage.php
@@ -262,7 +262,7 @@ class ThemeDesktopBackgroundImage implements ModelInterface, ArrayAccess, \JsonS
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('document_id', $data ?? [], null);
         $this->setIfExists('size1920x1080', $data ?? [], null);

--- a/lib/Api/Model/ThemeImageCreateInput.php
+++ b/lib/Api/Model/ThemeImageCreateInput.php
@@ -244,7 +244,7 @@ class ThemeImageCreateInput implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('document_id', $data ?? [], null);
     }

--- a/lib/Api/Model/ThemeImageUpdateInput.php
+++ b/lib/Api/Model/ThemeImageUpdateInput.php
@@ -244,7 +244,7 @@ class ThemeImageUpdateInput implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('document_id', $data ?? [], null);
     }

--- a/lib/Api/Model/ThemeMobileBackgroundImage.php
+++ b/lib/Api/Model/ThemeMobileBackgroundImage.php
@@ -262,7 +262,7 @@ class ThemeMobileBackgroundImage implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('document_id', $data ?? [], null);
         $this->setIfExists('size1920x1080', $data ?? [], null);

--- a/lib/Api/Model/ThemePage.php
+++ b/lib/Api/Model/ThemePage.php
@@ -256,7 +256,7 @@ class ThemePage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/ThemePaymentMethodSelector.php
+++ b/lib/Api/Model/ThemePaymentMethodSelector.php
@@ -244,7 +244,7 @@ class ThemePaymentMethodSelector implements ModelInterface, ArrayAccess, \JsonSe
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('colors', $data ?? [], null);
     }

--- a/lib/Api/Model/ThemePaymentMethodSelectorColors.php
+++ b/lib/Api/Model/ThemePaymentMethodSelectorColors.php
@@ -268,7 +268,7 @@ class ThemePaymentMethodSelectorColors implements ModelInterface, ArrayAccess, \
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background', $data ?? [], null);
         $this->setIfExists('border', $data ?? [], null);

--- a/lib/Api/Model/ThemePaymentMethodSelectorColorsCreateInput.php
+++ b/lib/Api/Model/ThemePaymentMethodSelectorColorsCreateInput.php
@@ -268,7 +268,7 @@ class ThemePaymentMethodSelectorColorsCreateInput implements ModelInterface, Arr
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background', $data ?? [], null);
         $this->setIfExists('border', $data ?? [], null);

--- a/lib/Api/Model/ThemePaymentMethodSelectorColorsUpdateInput.php
+++ b/lib/Api/Model/ThemePaymentMethodSelectorColorsUpdateInput.php
@@ -268,7 +268,7 @@ class ThemePaymentMethodSelectorColorsUpdateInput implements ModelInterface, Arr
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background', $data ?? [], null);
         $this->setIfExists('border', $data ?? [], null);

--- a/lib/Api/Model/ThemePaymentMethodSelectorCreateInput.php
+++ b/lib/Api/Model/ThemePaymentMethodSelectorCreateInput.php
@@ -244,7 +244,7 @@ class ThemePaymentMethodSelectorCreateInput implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('colors', $data ?? [], null);
     }

--- a/lib/Api/Model/ThemePaymentMethodSelectorUpdateInput.php
+++ b/lib/Api/Model/ThemePaymentMethodSelectorUpdateInput.php
@@ -244,7 +244,7 @@ class ThemePaymentMethodSelectorUpdateInput implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('colors', $data ?? [], null);
     }

--- a/lib/Api/Model/ThemeUpdateInput.php
+++ b/lib/Api/Model/ThemeUpdateInput.php
@@ -268,7 +268,7 @@ class ThemeUpdateInput implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('background_image', $data ?? [], null);
         $this->setIfExists('colors', $data ?? [], null);

--- a/lib/Api/Model/Webhook.php
+++ b/lib/Api/Model/Webhook.php
@@ -273,7 +273,7 @@ class Webhook implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('headers', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/lib/Api/Model/WebhookCreateInput.php
+++ b/lib/Api/Model/WebhookCreateInput.php
@@ -256,7 +256,7 @@ class WebhookCreateInput implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('headers', $data ?? [], null);
         $this->setIfExists('subscribed_events', $data ?? [], null);

--- a/lib/Api/Model/WebhookPage.php
+++ b/lib/Api/Model/WebhookPage.php
@@ -256,7 +256,7 @@ class WebhookPage implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('pageable', $data ?? [], null);
         $this->setIfExists('results', $data ?? [], null);

--- a/lib/Api/Model/WebhookUpdateInput.php
+++ b/lib/Api/Model/WebhookUpdateInput.php
@@ -262,7 +262,7 @@ class WebhookUpdateInput implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('headers', $data ?? [], null);
         $this->setIfExists('status', $data ?? [], null);

--- a/lib/Api/Model/WoocommerceConnectionData.php
+++ b/lib/Api/Model/WoocommerceConnectionData.php
@@ -254,7 +254,7 @@ class WoocommerceConnectionData extends ConnectionData
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/WoocommerceConnectionDataInput.php
+++ b/lib/Api/Model/WoocommerceConnectionDataInput.php
@@ -248,7 +248,7 @@ class WoocommerceConnectionDataInput extends ConnectionDataInput
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/ZopaRetailFinanceConnectionData.php
+++ b/lib/Api/Model/ZopaRetailFinanceConnectionData.php
@@ -266,7 +266,7 @@ class ZopaRetailFinanceConnectionData extends ConnectionData
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/ZopaRetailFinanceConnectionDataInput.php
+++ b/lib/Api/Model/ZopaRetailFinanceConnectionDataInput.php
@@ -260,7 +260,7 @@ class ZopaRetailFinanceConnectionDataInput extends ConnectionDataInput
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Api/Model/ZopaRetailFinancePageSettings.php
+++ b/lib/Api/Model/ZopaRetailFinancePageSettings.php
@@ -244,7 +244,7 @@ class ZopaRetailFinancePageSettings implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('widget', $data ?? [], null);
     }

--- a/lib/Api/Model/ZopaRetailFinancePaymentMethodSettings.php
+++ b/lib/Api/Model/ZopaRetailFinancePaymentMethodSettings.php
@@ -250,7 +250,7 @@ class ZopaRetailFinancePaymentMethodSettings implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('product', $data ?? [], null);
         $this->setIfExists('sdk_api_key', $data ?? [], null);

--- a/lib/Api/Model/ZopaRetailFinanceWidgetSettings.php
+++ b/lib/Api/Model/ZopaRetailFinanceWidgetSettings.php
@@ -244,7 +244,7 @@ class ZopaRetailFinanceWidgetSettings implements ModelInterface, ArrayAccess, \J
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('enabled', $data ?? [], null);
     }

--- a/lib/Api/NotificationsApi.php
+++ b/lib/Api/NotificationsApi.php
@@ -84,15 +84,15 @@ class NotificationsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/OrdersApi.php
+++ b/lib/Api/OrdersApi.php
@@ -81,15 +81,15 @@ class OrdersApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/PaymentLinksApi.php
+++ b/lib/Api/PaymentLinksApi.php
@@ -87,15 +87,15 @@ class PaymentLinksApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/PaymentMethodsApi.php
+++ b/lib/Api/PaymentMethodsApi.php
@@ -78,15 +78,15 @@ class PaymentMethodsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/PaymentSessionsApi.php
+++ b/lib/Api/PaymentSessionsApi.php
@@ -81,15 +81,15 @@ class PaymentSessionsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/PaymentSettingsApi.php
+++ b/lib/Api/PaymentSettingsApi.php
@@ -78,15 +78,15 @@ class PaymentSettingsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/PublicApi.php
+++ b/lib/Api/PublicApi.php
@@ -300,15 +300,15 @@ class PublicApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/RefundsApi.php
+++ b/lib/Api/RefundsApi.php
@@ -78,15 +78,15 @@ class RefundsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/ShipmentTrackingApi.php
+++ b/lib/Api/ShipmentTrackingApi.php
@@ -81,15 +81,15 @@ class ShipmentTrackingApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/StatementExportsApi.php
+++ b/lib/Api/StatementExportsApi.php
@@ -78,15 +78,15 @@ class StatementExportsApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/ThemesApi.php
+++ b/lib/Api/ThemesApi.php
@@ -87,15 +87,15 @@ class ThemesApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ?ClientInterface $client
+     * @param ?Configuration   $config
+     * @param ?HeaderSelector  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Api/WebhooksApi.php
+++ b/lib/Api/WebhooksApi.php
@@ -87,15 +87,15 @@ class WebhooksApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
+     * @param ClientInterface | null $client
+     * @param Configuration | null   $config
+     * @param HeaderSelector | null  $selector
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -487,7 +487,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostSettings, $hostIndex, array $variables = null)
+    public static function getHostString(array $hostSettings, $hostIndex, ?array $variables = null)
     {
         if (null === $variables) {
             $variables = [];

--- a/templates/model_generic.mustache
+++ b/templates/model_generic.mustache
@@ -234,7 +234,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         {{#parentSchema}}
         parent::__construct($data);


### PR DESCRIPTION
There were a large number of files here that had incompatible code with PHP 8.4
These were all `implicitly nullable via default value null` errors, and have all been resolved.

As this is a dependency of the `rvvup/module-magento-payments` and `rvvup/module-magento-payments-hyva-checkout` packages, and both those modules have been brought up to PHP 8.4 compatability, this should also be brought up to that same standard